### PR TITLE
Query parameters support

### DIFF
--- a/CustardApi/Objects/Service.cs
+++ b/CustardApi/Objects/Service.cs
@@ -557,19 +557,19 @@ namespace CustardApi.Objects
         /// </summary>
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller"></param>
-        /// <param name="jsonBody"></param>
+        /// <param name="payload">string payload</param>
         /// <param name="action"></param>
         /// <param name="httpMethod"></param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>response of the method in the form of a model</returns>
-        private async Task<T> Process<T>(string controller, string contentType, string jsonBody, string action, string[] parameters, HttpMethod httpMethod, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        private async Task<T> Process<T>(string controller, string contentType, string payload, string action, string[] parameters, HttpMethod httpMethod, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
         {
             try
             {
                 string methodUrl = BuildUrl(controller, action, parameters);
 
                 // Build the request
-                return await ProcessRequest<T>(contentType, jsonBody, httpMethod, unSuccessCallback: unSuccessCallback, singleUseHeaders, methodUrl);
+                return await ProcessRequest<T>(contentType, payload, httpMethod, unSuccessCallback: unSuccessCallback, singleUseHeaders, methodUrl);
             }
             catch (Exception ex)
             {
@@ -607,19 +607,19 @@ namespace CustardApi.Objects
         /// </summary>
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller"></param>
-        /// <param name="jsonBody"></param>
+        /// <param name="payload">string payload</param>
         /// <param name="action"></param>
         /// <param name="httpMethod"></param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>response of the method in the form of a model</returns>
-        private async Task<T> Process<T>(string controller, string contentType, string jsonBody, string action, IDictionary<string, string> parameters, HttpMethod httpMethod, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        private async Task<T> Process<T>(string controller, string contentType, string payload, string action, IDictionary<string, string> parameters, HttpMethod httpMethod, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
         {
             try
             {
                 string methodUrl = BuildUrl(controller, action, parameters);
 
                 // Build the request
-                return await ProcessRequest<T>(contentType, jsonBody, httpMethod, unSuccessCallback: unSuccessCallback, singleUseHeaders, methodUrl);
+                return await ProcessRequest<T>(contentType, payload, httpMethod, unSuccessCallback: unSuccessCallback, singleUseHeaders, methodUrl);
             }
             catch (Exception ex)
             {

--- a/CustardApi/Objects/Service.cs
+++ b/CustardApi/Objects/Service.cs
@@ -54,6 +54,7 @@ namespace CustardApi.Objects
             // Set the base url up then
             _baseUrl = $"{ (_sslCertificate ? "https" : "http")}://{ _host}{ (_port == 80 ? "/" : ":" + _port + "/")}";
         }
+        #region Path parameters requests
         /// <summary>
         /// Execute a post method without header and return a model
         /// </summary>
@@ -64,7 +65,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// 
         /// <returns>Result of the request</returns>
-        public  Task<T> Post<T>(string controller, string jsonBody, string action = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        public Task<T> Post<T>(string controller, string jsonBody, string action = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
         {
 
             return Process<T>(controller, "application/json", jsonBody, action, parameters, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
@@ -189,10 +190,10 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<T> Post<T>(string controller, string action = null, HttpContent httpContent = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        public Task<T> Post<T>(string controller, string action = null, HttpContent httpContent = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
         {
 
-            return Process<T>(controller, httpContent, action, parameters, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+            return Process<T>(controller,contentType, httpContent, action, parameters, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
         }
 
         /// <summary>
@@ -208,7 +209,7 @@ namespace CustardApi.Objects
         public Task<T> Get<T>(string controller, string action = null, HttpContent httpContent = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
         {
 
-            return Process<T>(controller, httpContent, action, parameters, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+            return Process<T>(controller, contentType, httpContent, action, parameters, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
         }
         /// <summary>
         /// Execute a put method and return a model
@@ -223,7 +224,7 @@ namespace CustardApi.Objects
         {
 
 
-            return Process<T>(controller, httpContent, action, parameters, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+            return Process<T>(controller, contentType, httpContent, action, parameters, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
         }
         /// <summary>
         /// Execute a delete method and return a model
@@ -238,7 +239,7 @@ namespace CustardApi.Objects
         {
 
             // Get the reponse
-            return Process<T>(controller, httpContent, action, parameters, HttpMethod.Delete, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+            return Process<T>(controller, contentType, httpContent, action, parameters, HttpMethod.Delete, unSuccessCallback, singleUseHeaders: singleUseHeaders);
         }
 
         /// <summary>
@@ -253,7 +254,7 @@ namespace CustardApi.Objects
         public Task<string> Get(string controller, string action = null, HttpContent httpContent = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
         {
 
-            return Process<string>(controller, httpContent, action, parameters, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+            return Process<string>(controller, contentType, httpContent, action, parameters, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
         }
         /// <summary>
         /// Execute a put method and return a model
@@ -266,7 +267,7 @@ namespace CustardApi.Objects
         /// <returns>Result of the request</returns>
         public Task<string> Put(string controller, string action = null, HttpContent httpContent = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
         {
-            return Process<string>(controller, httpContent, action, parameters, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+            return Process<string>(controller, contentType, httpContent, action, parameters, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
         }
         /// <summary>
         /// Execute a post method and return a model
@@ -281,7 +282,7 @@ namespace CustardApi.Objects
         {
 
             // Get the reponse
-            return Process<string>(controller,  httpContent, action, parameters, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+            return Process<string>(controller, contentType, httpContent, action, parameters, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
         }
         /// <summary>
         /// Execute a delete method and return a model
@@ -297,17 +298,267 @@ namespace CustardApi.Objects
         {
 
             // Get the reponse
-            return Process<string>(controller, httpContent, action, parameters, HttpMethod.Delete, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+            return Process<string>(controller, contentType, httpContent, action, parameters, HttpMethod.Delete, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        #endregion
+
+        #region Query parameters requests
+        /// <summary>
+        /// Execute a post method without header and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// 
+        /// <returns>Result of the request</returns>
+        public Task<T> Post<T>(string controller, string jsonBody, string action = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            return Process<T>(controller, "application/json", jsonBody, action, parameters, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        /// <summary>
+        /// Execute a get method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Get<T>(string controller, string jsonBody, string action = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            return Process<T>(controller, "application/json", jsonBody, action, parameters, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
         }
         /// <summary>
-        /// Get get a response
+        /// Execute a put method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Put<T>(string controller, string jsonBody, string action = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+
+            return Process<T>(controller, "application/json", jsonBody, action, parameters, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a delete method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Delete<T>(string controller, string jsonBody, string action = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            // Get the reponse
+            return Process<T>(controller, "application/json", jsonBody, action, parameters, HttpMethod.Delete, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        /// <summary>
+        /// Execute a get method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Get(string controller, string jsonBody, string action = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            return Process<string>(controller, "application/json", jsonBody, action, parameters, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a put method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Put(string controller, string jsonBody, string action = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+            return Process<string>(controller, "application/json", jsonBody, action, parameters, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a post method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Post(string controller, string jsonBody, string action = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            // Get the reponse
+            return Process<string>(controller, "application/json", jsonBody, action, parameters, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a delete method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Delete(string controller, string jsonBody, string action = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            // Get the reponse
+            return Process<string>(controller, "application/json", jsonBody, action, parameters, HttpMethod.Delete, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a post method without header and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="httpContent">httpContent</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Post<T>(string controller, string action = null, HttpContent httpContent = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        {
+
+            return Process<T>(controller, contentType, httpContent, action, parameters, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        /// <summary>
+        /// Execute a get method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="httpContent">httpContent</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Get<T>(string controller, string action = null, HttpContent httpContent = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        {
+
+            return Process<T>(controller, contentType, httpContent, action, parameters, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a put method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Put<T>(string controller, string action = null, HttpContent httpContent = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        {
+
+
+            return Process<T>(controller, contentType, httpContent, action, parameters, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a delete method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Delete<T>(string controller, string action = null, HttpContent httpContent = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        {
+
+            // Get the reponse
+            return Process<T>(controller, contentType, httpContent, action, parameters, HttpMethod.Delete, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        /// <summary>
+        /// Execute a get method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Get(string controller, string action = null, HttpContent httpContent = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        {
+
+            return Process<string>(controller, contentType, httpContent, action, parameters, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a put method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Put(string controller, string action = null, HttpContent httpContent = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        {
+            return Process<string>(controller, contentType, httpContent, action, parameters, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a post method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Post(string controller, string action = null, HttpContent httpContent = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        {
+
+            // Get the reponse
+            return Process<string>(controller, contentType, httpContent, action, parameters, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a delete method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Delete(string controller, string action = null, HttpContent httpContent = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        {
+
+            // Get the reponse
+            return Process<string>(controller, contentType, httpContent, action, parameters, HttpMethod.Delete, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Get get a response of a path request using a string content
         /// </summary>
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller"></param>
         /// <param name="jsonBody"></param>
         /// <param name="action"></param>
-        /// <param name="headers"></param>
-        /// <param name="headers"></param>
         /// <param name="httpMethod"></param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>response of the method in the form of a model</returns>
@@ -315,19 +566,10 @@ namespace CustardApi.Objects
         {
             try
             {
-                var result = default(T);
-                // Build the url
-                string methodUrl = _baseUrl + controller + (string.IsNullOrEmpty(action) ? "" : "/" + action);
-
-                // If there are some parameters
-                methodUrl = CreateUrl(parameters, methodUrl);
-
-                LastCall = methodUrl;
+                string methodUrl = BuildUrl(controller, action, parameters);
 
                 // Build the request
-                result = await ProcessRequest(contentType, jsonBody, httpMethod, unSuccessCallback, singleUseHeaders, result, methodUrl);
-
-                return result;
+                return await ProcessRequest<T>(contentType, jsonBody, httpMethod, unSuccessCallback: unSuccessCallback, singleUseHeaders, methodUrl);
             }
             catch (Exception ex)
             {
@@ -339,90 +581,138 @@ namespace CustardApi.Objects
         }
 
         /// <summary>
-        /// Get get a response
+        /// Get get a response of a path request using a HttpContent
         /// </summary>
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller"></param>
-        /// <param name="jsonBody"></param>
+        /// <param name="httpContent"></param>
         /// <param name="action"></param>
-        /// <param name="headers"></param>
-        /// <param name="headers"></param>
         /// <param name="httpMethod"></param>
         /// <returns>response of the method in the form of a model</returns>
-        private async Task<T> Process<T>(string controller, HttpContent httpContent, string action, string[] parameters, HttpMethod httpMethod, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, IDictionary<string, string> headers = null)
+        private async Task<T> Process<T>(string controller, string contentType, HttpContent httpContent, string action, string[] parameters, HttpMethod httpMethod, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
         {
             try
             {
-                var result = default(T);
-                // Build the url
-                string methodUrl = _baseUrl + controller + (string.IsNullOrEmpty(action) ? "" : "/" + action);
+                string methodUrl = BuildUrl(controller, action, parameters);
 
-                // If there are some parameters
-                methodUrl = CreateUrl(parameters, methodUrl);
-                LastCall = methodUrl;
-                // Build the request
-                using (var request = new HttpRequestMessage(httpMethod, methodUrl))
-                {
-                    // Content of the request
-                    if (httpContent != null)
-                    {
-                        request.Content = httpContent;
-                    }
-
-                    // These are the headers we'll use in the request 
-                    Dictionary<string, string> reqHeaders = new Dictionary<string, string>();
-
-                    // Merge single use headers with actual headers
-                    if (singleUseHeaders != null)
-                        reqHeaders = this._requestHeaders.Concat(singleUseHeaders)
-                                                         .ToLookup(x => x.Key, x => x.Value)
-                                                         .ToDictionary(x => x.Key, g => g.First());
-                    else
-                        reqHeaders = this._requestHeaders;
-
-                    LastCallRequestHeaders = reqHeaders;
-
-                    // Headers of the request
-                    if (reqHeaders != null)
-                        foreach (var h in reqHeaders)
-                        {
-                            request.Headers.Add(h.Key, h.Value);
-                        }
-
-                    // Handler
-                    try
-                    {
-                        using var handler = new HttpClientHandler();
-                        using var client = new HttpClient(handler);
-                        using var response = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
-
-                        var content = response.Content == null ? null : await response.Content.ReadAsStringAsync();
-
-                        if (!response.IsSuccessStatusCode)
-                            unSuccessCallback?.Invoke(response);
-
-                        if (typeof(T) == typeof(string))
-                            result = (T)(object)(response.Content == null ? null : await response.Content.ReadAsStringAsync());
-                        else if (content != null)
-                            result = JsonConvert.DeserializeObject<T>(content);
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new Exception("[Issue Handler]: " + ex.Message);
-                    }
-
-                }
-
-                return await ProcessRequest(contentType, jsonBody, httpMethod, unSuccessCallback, singleUseHeaders, result, methodUrl);
+                return await ProcessRequest<T>(contentType: contentType, httpContent: httpContent, httpMethod: httpMethod, unSuccessCallback: unSuccessCallback, singleUseHeaders: singleUseHeaders, methodUrl: methodUrl);
             }
             catch (Exception ex)
             {
                 throw new Exception("[Issue Handler]: " + ex.Message);
             }
+        }
+        /// <summary>
+        /// Get get a response of a query request using a string content
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller"></param>
+        /// <param name="jsonBody"></param>
+        /// <param name="action"></param>
+        /// <param name="httpMethod"></param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>response of the method in the form of a model</returns>
+        private async Task<T> Process<T>(string controller, string contentType, string jsonBody, string action, IDictionary<string, string> parameters, HttpMethod httpMethod, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+            try
+            {
+                string methodUrl = BuildUrl(controller, action, parameters);
 
+                // Build the request
+                return await ProcessRequest<T>(contentType, jsonBody, httpMethod, unSuccessCallback: unSuccessCallback, singleUseHeaders, methodUrl);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("[Issue Handler]: " + ex.Message);
+            }
+            
 
 
         }
+
+        /// <summary>
+        /// Get get a response of a query request using a HttpContent
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller"></param>
+        /// <param name="httpContent"></param>
+        /// <param name="action"></param>
+        /// <param name="httpMethod"></param>
+        /// <returns>response of the method in the form of a model</returns>
+        private async Task<T> Process<T>(string controller, string contentType, HttpContent httpContent, string action, IDictionary<string, string> parameters, HttpMethod httpMethod, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+            try
+            {
+                string methodUrl = BuildUrl(controller, action, parameters);
+
+                return await ProcessRequest<T>(contentType: contentType, httpContent: httpContent, httpMethod: httpMethod, unSuccessCallback: unSuccessCallback, singleUseHeaders: singleUseHeaders, methodUrl: methodUrl);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("[Issue Handler]: " + ex.Message);
+            }
+        }
+        /// <summary>
+        /// Build a complete url with all the data needed for path parameters
+        /// </summary>
+        /// <param name="controller"></param>
+        /// <param name="action"></param>
+        /// <param name="parameters"></param>
+        /// <returns></returns>
+        private string BuildUrl(string controller, string action, string[] parameters)
+        {
+            // Build the url
+            string methodUrl = _baseUrl + controller + (string.IsNullOrEmpty(action) ? "" : "/" + action);
+
+            // If there are some parameters
+            LastCall = methodUrl = CreateUrl(parameters, methodUrl);
+            return methodUrl;
+        }
+        /// <summary>
+        /// Build a complete url with all the data needed for query parameters
+        /// </summary>
+        /// <param name="controller"></param>
+        /// <param name="action"></param>
+        /// <param name="parameters"></param>
+        /// <returns></returns>
+        private string BuildUrl(string controller, string action, IDictionary<string, string> parameters)
+        {
+            // Build the url
+            string methodUrl = _baseUrl + controller + (string.IsNullOrEmpty(action) ? "" : "/" + action);
+
+            // If there are some parameters
+            LastCall = methodUrl = CreateUrl(parameters, methodUrl);
+            return methodUrl;
+        }
+
+        /// <summary>
+        /// Send the request
+        /// </summary>
+        /// <param name="contentType"></param>
+        /// <param name="jsonBody"></param>
+        /// <param name="httpMethod"></param>
+        /// <param name="unSuccessCallback"></param>
+        /// <param name="singleUseHeaders"></param>
+        /// <param name="result"></param>
+        /// <param name="methodUrl"></param>
+        /// <returns></returns>
+        /// <exception cref="Exception"></exception>
+        private async Task<T> ProcessRequest<T>(string contentType, string jsonBody, HttpMethod httpMethod, Action<HttpResponseMessage> unSuccessCallback, IDictionary<string, string> singleUseHeaders, string methodUrl)
+        {
+            var result = default(T);
+            using (var request = new HttpRequestMessage(httpMethod, methodUrl))
+            {
+                // Content of the request
+                request.Content = SetContentRequestFromString(contentType, jsonBody);
+
+                // Send the request
+                result = await SendRequest<T>(unSuccessCallback, singleUseHeaders, request);
+
+            }
+
+            return result;
+        }
+
         /// <summary>
         /// Send the request
         /// </summary>
@@ -436,61 +726,93 @@ namespace CustardApi.Objects
         /// <param name="methodUrl"></param>
         /// <returns></returns>
         /// <exception cref="Exception"></exception>
-        private async Task<T> ProcessRequest<T>(string contentType, string jsonBody, HttpMethod httpMethod, Action<HttpResponseMessage> unSuccessCallback, IDictionary<string, string> singleUseHeaders, T result, string methodUrl)
+        private async Task<T> ProcessRequest<T>(string contentType, HttpContent httpContent, HttpMethod httpMethod, Action<HttpResponseMessage> unSuccessCallback, IDictionary<string, string> singleUseHeaders, string methodUrl)
         {
+            var result = default(T);
             using (var request = new HttpRequestMessage(httpMethod, methodUrl))
             {
                 // Content of the request
-                if (jsonBody != null)
+                request.Content = httpContent;
+
+                // Send the request
+                result = await SendRequest<T>(unSuccessCallback, singleUseHeaders, request);
+
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Build the content of a request
+        /// </summary>
+        /// <param name="contentType"></param>
+        /// <param name="jsonBody"></param>
+        /// <returns></returns>
+        private static HttpContent SetContentRequestFromString(string contentType, string jsonBody)
+        {
+            if (jsonBody != null)
+            {
+                return new StringContent(jsonBody, Encoding.UTF8, contentType);
+            }
+            return null;
+
+        }
+        /// <summary>
+        /// Send the http request
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="unSuccessCallback"></param>
+        /// <param name="singleUseHeaders"></param>
+        /// <param name="result"></param>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        /// <exception cref="Exception"></exception>
+        private async Task<T> SendRequest<T>(Action<HttpResponseMessage> unSuccessCallback, IDictionary<string, string> singleUseHeaders, HttpRequestMessage request)
+        {
+            var result = default(T);
+            // These are the headers we'll use in the request 
+            Dictionary<string, string> reqHeaders = new Dictionary<string, string>();
+
+            // Merge single use headers with actual headers
+            if (singleUseHeaders != null)
+                reqHeaders = this._requestHeaders.Concat(singleUseHeaders)
+                                                 .ToLookup(x => x.Key, x => x.Value)
+                                                 .ToDictionary(x => x.Key, g => g.First());
+            else
+                reqHeaders = this._requestHeaders;
+
+            LastCallRequestHeaders = reqHeaders;
+
+            // Headers of the request
+            if (reqHeaders != null)
+                foreach (var h in reqHeaders)
                 {
-                    request.Content = new StringContent(jsonBody, Encoding.UTF8, contentType);
+                    request.Headers.Add(h.Key, h.Value);
                 }
 
-                // These are the headers we'll use in the request 
-                Dictionary<string, string> reqHeaders = new Dictionary<string, string>();
+            // Handler
+            try
+            {
+                using var handler = new HttpClientHandler();
+                using var client = new HttpClient(handler);
+                using var response = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
 
-                // Merge single use headers with actual headers
-                if (singleUseHeaders != null)
-                    reqHeaders = this._requestHeaders.Concat(singleUseHeaders)
-                                                     .ToLookup(x => x.Key, x => x.Value)
-                                                     .ToDictionary(x => x.Key, g => g.First());
-                else
-                    reqHeaders = this._requestHeaders;
+                var content = response.Content == null ? null : await response.Content.ReadAsStringAsync();
 
-                LastCallRequestHeaders = reqHeaders;
+                if (!response.IsSuccessStatusCode)
+                    unSuccessCallback?.Invoke(response);
 
-                // Headers of the request
-                if (reqHeaders != null)
-                    foreach (var h in reqHeaders)
-                    {
-                        request.Headers.Add(h.Key, h.Value);
-                    }
-
-                // Handler
-                try
-                {
-                    using var handler = new HttpClientHandler();
-                    using var client = new HttpClient(handler);
-                    using var response = await client.SendAsync(request, HttpCompletionOption.ResponseContentRead);
-
-                    var content = response.Content == null ? null : await response.Content.ReadAsStringAsync();
-
-                    if (!response.IsSuccessStatusCode)
-                        unSuccessCallback?.Invoke(response);
-
-                    if (typeof(T) == typeof(string))
-                        result = (T)(object)(response.Content == null ? null : await response.Content.ReadAsStringAsync());
-                    else if (content != null)
-                        result = JsonConvert.DeserializeObject<T>(content);
+                if (typeof(T) == typeof(string))
+                    result = (T)(object)(response.Content == null ? null : await response.Content.ReadAsStringAsync());
+                else if (content != null)
+                    result = JsonConvert.DeserializeObject<T>(content);
 
 
-                }
-                catch (Exception ex)
-                {
+            }
+            catch (Exception ex)
+            {
 
-                    throw new Exception("[Issue Handler]: " + ex.Message);
-                }
-
+                throw new Exception("[Issue Handler]: " + ex.Message);
             }
 
             return result;
@@ -517,7 +839,7 @@ namespace CustardApi.Objects
         /// <param name="parameters">List of parameters</param>
         /// <param name="initialUrl">The base url</param>
         /// <returns>The url with all the parameters</returns>
-        private static string CreateUrl(Dictionary<string,string> parameters, string initialUrl)
+        private static string CreateUrl(IDictionary<string,string> parameters, string initialUrl)
         {
             if (parameters != null)
             {

--- a/CustardApi/Objects/Service.cs
+++ b/CustardApi/Objects/Service.cs
@@ -1468,16 +1468,19 @@ namespace CustardApi.Objects
         /// <returns>Full url of the request</returns>
         private string BuildUrl(string controller, string action, string[] parameters= null)
         {
-            if (parameters == null)
-                return _baseUrl + controller;
 
             // Build the url
-            string methodUrl = _baseUrl + controller + (string.IsNullOrEmpty(action) ? "" : "/" + action);
+            string methodUrl = GetBaseMethodUrl(controller, action);
+
+            if (parameters == null)
+                return methodUrl;
+
 
             // If there are some parameters
             LastCall = methodUrl = CreateUrl(parameters, methodUrl);
             return methodUrl;
         }
+
         /// <summary>
         /// Build a complete url with all the data needed for query parameters
         /// </summary>
@@ -1488,11 +1491,21 @@ namespace CustardApi.Objects
         private string BuildUrl(string controller, string action, IDictionary<string, string> parameters)
         {
             // Build the url
-            string methodUrl = _baseUrl + controller + (string.IsNullOrEmpty(action) ? "" : "/" + action);
+            string methodUrl = GetBaseMethodUrl(controller, action);
 
             // If there are some parameters
             LastCall = methodUrl = CreateUrl(parameters, methodUrl);
             return methodUrl;
+        }
+        /// <summary>
+        /// Get url from controller and action
+        /// </summary>
+        /// <param name="controller">controller of the method</param>
+        /// <param name="action">action of the met</param>
+        /// <returns></returns>
+        private string GetBaseMethodUrl(string controller, string action)
+        {
+            return _baseUrl + controller + (string.IsNullOrEmpty(action) ? "" : "/" + action);
         }
 
         /// <summary>

--- a/CustardApi/Objects/Service.cs
+++ b/CustardApi/Objects/Service.cs
@@ -65,7 +65,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// 
         /// <returns>Result of the request</returns>
-        public Task<T> Post<T>(string controller, string jsonBody, string action = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        public Task<T> Post<T>(string controller, string jsonBody, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
         {
 
             return Process<T>(controller, "application/json", jsonBody, action, parameters, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
@@ -81,7 +81,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<T> Get<T>(string controller, string jsonBody, string action = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        public Task<T> Get<T>(string controller, string jsonBody, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
         {
 
             return Process<T>(controller, "application/json", jsonBody, action, parameters, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
@@ -96,7 +96,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<T> Put<T>(string controller, string jsonBody, string action = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        public Task<T> Put<T>(string controller, string jsonBody, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
         {
 
 
@@ -112,7 +112,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<T> Delete<T>(string controller, string jsonBody, string action = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        public Task<T> Delete<T>(string controller, string jsonBody, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
         {
 
             // Get the reponse
@@ -129,7 +129,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<string> Get(string controller, string jsonBody, string action = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        public Task<string> Get(string controller, string jsonBody, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
         {
 
             return Process<string>(controller, "application/json", jsonBody, action, parameters, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
@@ -144,7 +144,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<string> Put(string controller, string jsonBody, string action = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        public Task<string> Put(string controller, string jsonBody, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
         {
             return Process<string>(controller, "application/json", jsonBody, action, parameters, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
         }
@@ -158,7 +158,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<string> Post(string controller, string jsonBody, string action = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        public Task<string> Post(string controller, string jsonBody, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
         {
 
             // Get the reponse
@@ -174,7 +174,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<string> Delete(string controller, string jsonBody, string action = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        public Task<string> Delete(string controller, string jsonBody, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
         {
 
             // Get the reponse
@@ -190,7 +190,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<T> Post<T>(string controller, string action = null, HttpContent httpContent = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        public Task<T> Post<T>(string controller, HttpContent httpContent, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
         {
 
             return Process<T>(controller,contentType, httpContent, action, parameters, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
@@ -206,7 +206,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<T> Get<T>(string controller, string action = null, HttpContent httpContent = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        public Task<T> Get<T>(string controller, HttpContent httpContent, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
         {
 
             return Process<T>(controller, contentType, httpContent, action, parameters, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
@@ -220,7 +220,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<T> Put<T>(string controller, string action = null, HttpContent httpContent = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        public Task<T> Put<T>(string controller, HttpContent httpContent, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
         {
 
 
@@ -235,7 +235,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<T> Delete<T>(string controller, string action = null, HttpContent httpContent = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        public Task<T> Delete<T>(string controller, HttpContent httpContent, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
         {
 
             // Get the reponse
@@ -251,7 +251,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<string> Get(string controller, string action = null, HttpContent httpContent = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        public Task<string> Get(string controller, HttpContent httpContent, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
         {
 
             return Process<string>(controller, contentType, httpContent, action, parameters, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
@@ -265,7 +265,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<string> Put(string controller, string action = null, HttpContent httpContent = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        public Task<string> Put(string controller, HttpContent httpContent, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
         {
             return Process<string>(controller, contentType, httpContent, action, parameters, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
         }
@@ -278,7 +278,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<string> Post(string controller, string action = null, HttpContent httpContent = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        public Task<string> Post(string controller, HttpContent httpContent, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
         {
 
             // Get the reponse
@@ -294,7 +294,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<string> Delete(string controller, string action = null, HttpContent httpContent = null, string[] parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        public Task<string> Delete(string controller, HttpContent httpContent, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
         {
 
             // Get the reponse
@@ -314,7 +314,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// 
         /// <returns>Result of the request</returns>
-        public Task<T> Post<T>(string controller, string jsonBody, string action = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        public Task<T> Post<T>(string controller, string jsonBody, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
         {
 
             return Process<T>(controller, "application/json", jsonBody, action, parameters, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
@@ -330,7 +330,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<T> Get<T>(string controller, string jsonBody, string action = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        public Task<T> Get<T>(string controller, string jsonBody, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
         {
 
             return Process<T>(controller, "application/json", jsonBody, action, parameters, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
@@ -345,7 +345,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<T> Put<T>(string controller, string jsonBody, string action = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        public Task<T> Put<T>(string controller, string jsonBody, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
         {
 
 
@@ -361,7 +361,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<T> Delete<T>(string controller, string jsonBody, string action = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        public Task<T> Delete<T>(string controller, string jsonBody, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
         {
 
             // Get the reponse
@@ -378,7 +378,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<string> Get(string controller, string jsonBody, string action = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        public Task<string> Get(string controller, string jsonBody, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
         {
 
             return Process<string>(controller, "application/json", jsonBody, action, parameters, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
@@ -393,7 +393,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<string> Put(string controller, string jsonBody, string action = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        public Task<string> Put(string controller, string jsonBody, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
         {
             return Process<string>(controller, "application/json", jsonBody, action, parameters, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
         }
@@ -407,7 +407,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<string> Post(string controller, string jsonBody, string action = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        public Task<string> Post(string controller, string jsonBody, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
         {
 
             // Get the reponse
@@ -423,7 +423,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<string> Delete(string controller, string jsonBody, string action = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        public Task<string> Delete(string controller, string jsonBody, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
         {
 
             // Get the reponse
@@ -439,7 +439,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<T> Post<T>(string controller, string action = null, HttpContent httpContent = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        public Task<T> Post<T>(string controller, HttpContent httpContent, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
         {
 
             return Process<T>(controller, contentType, httpContent, action, parameters, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
@@ -455,7 +455,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<T> Get<T>(string controller, string action = null, HttpContent httpContent = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        public Task<T> Get<T>(string controller, HttpContent httpContent, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
         {
 
             return Process<T>(controller, contentType, httpContent, action, parameters, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
@@ -469,7 +469,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<T> Put<T>(string controller, string action = null, HttpContent httpContent = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        public Task<T> Put<T>(string controller, HttpContent httpContent, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
         {
 
 
@@ -484,7 +484,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<T> Delete<T>(string controller, string action = null, HttpContent httpContent = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        public Task<T> Delete<T>(string controller, HttpContent httpContent, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
         {
 
             // Get the reponse
@@ -500,7 +500,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<string> Get(string controller, string action = null, HttpContent httpContent = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        public Task<string> Get(string controller, HttpContent httpContent, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
         {
 
             return Process<string>(controller, contentType, httpContent, action, parameters, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
@@ -514,7 +514,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<string> Put(string controller, string action = null, HttpContent httpContent = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        public Task<string> Put(string controller, HttpContent httpContent, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
         {
             return Process<string>(controller, contentType, httpContent, action, parameters, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
         }
@@ -527,7 +527,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<string> Post(string controller, string action = null, HttpContent httpContent = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        public Task<string> Post(string controller, HttpContent httpContent, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
         {
 
             // Get the reponse
@@ -543,7 +543,7 @@ namespace CustardApi.Objects
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
-        public Task<string> Delete(string controller, string action = null, HttpContent httpContent = null, IDictionary<string, string> parameters = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        public Task<string> Delete(string controller, HttpContent httpContent, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
         {
 
             // Get the reponse
@@ -551,6 +551,790 @@ namespace CustardApi.Objects
         }
 
         #endregion
+
+        #region without parameters
+        /// <summary>
+        /// Execute a post method without header and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// 
+        /// <returns>Result of the request</returns>
+        public Task<T> Post<T>(string controller, string jsonBody, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            return Process<T>(controller, "application/json", jsonBody, action, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        /// <summary>
+        /// Execute a get method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Get<T>(string controller, string jsonBody, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            return Process<T>(controller, "application/json", jsonBody, action, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a put method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Put<T>(string controller, string jsonBody, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+
+            return Process<T>(controller, "application/json", jsonBody, action, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a delete method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Delete<T>(string controller, string jsonBody, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            // Get the reponse
+            return Process<T>(controller, "application/json", jsonBody, action, HttpMethod.Delete, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        /// <summary>
+        /// Execute a get method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Get(string controller, string jsonBody, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            return Process<string>(controller, "application/json", jsonBody, action, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a put method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Put(string controller, string jsonBody, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+            return Process<string>(controller, "application/json", jsonBody, action, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a post method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Post(string controller, string jsonBody, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            // Get the reponse
+            return Process<string>(controller, "application/json", jsonBody, action, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a delete method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Delete(string controller, string jsonBody, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            // Get the reponse
+            return Process<string>(controller, "application/json", jsonBody, action, HttpMethod.Delete, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a post method without header and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="httpContent">httpContent</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Post<T>(string controller, HttpContent httpContent, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        {
+
+            return Process<T>(controller, contentType, httpContent, action, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        /// <summary>
+        /// Execute a get method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="httpContent">httpContent</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Get<T>(string controller, HttpContent httpContent, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        {
+
+            return Process<T>(controller, contentType, httpContent, action, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a put method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Put<T>(string controller, HttpContent httpContent, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        {
+
+
+            return Process<T>(controller, contentType, httpContent, action, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a delete method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Delete<T>(string controller, HttpContent httpContent,string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        {
+
+            // Get the reponse
+            return Process<T>(controller, contentType, httpContent, action, HttpMethod.Delete, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        /// <summary>
+        /// Execute a get method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Get(string controller, HttpContent httpContent, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        {
+
+            return Process<string>(controller, contentType, httpContent, action, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a put method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Put(string controller, HttpContent httpContent, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        {
+            return Process<string>(controller, contentType, httpContent, action, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a post method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Post(string controller, HttpContent httpContent, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        {
+
+            // Get the reponse
+            return Process<string>(controller, contentType, httpContent, action, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a delete method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Delete(string controller, HttpContent httpContent, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        {
+
+            // Get the reponse
+            return Process<string>(controller, contentType, httpContent, action, HttpMethod.Delete, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        #endregion
+
+        #region Without payload
+        #region Path parameters requests
+        /// <summary>
+        /// Execute a post method without header and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// 
+        /// <returns>Result of the request</returns>
+        public Task<T> Post<T>(string controller, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            return Process<T>(controller, "application/json", payload: null, action, parameters, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        /// <summary>
+        /// Execute a get method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Get<T>(string controller, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            return Process<T>(controller, "application/json", payload: null, action, parameters, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a put method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Put<T>(string controller, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+
+            return Process<T>(controller, "application/json", payload: null, action, parameters, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a delete method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Delete<T>(string controller, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            // Get the reponse
+            return Process<T>(controller, "application/json", payload: null, action, parameters, HttpMethod.Delete, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        /// <summary>
+        /// Execute a get method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Get(string controller, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            return Process<string>(controller, "application/json", payload: null, action, parameters, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a put method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Put(string controller, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+            return Process<string>(controller, "application/json", payload: null, action, parameters, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a post method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Post(string controller, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            // Get the reponse
+            return Process<string>(controller, "application/json", payload: null, action, parameters, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a delete method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Delete(string controller, string[] parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            // Get the reponse
+            return Process<string>(controller, "application/json", payload: null, action, parameters, HttpMethod.Delete, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        #endregion
+
+        #region Query parameters requests
+        /// <summary>
+        /// Execute a post method without header and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// 
+        /// <returns>Result of the request</returns>
+        public Task<T> Post<T>(string controller, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            return Process<T>(controller, "application/json", payload: null, action, parameters, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        /// <summary>
+        /// Execute a get method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Get<T>(string controller, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            return Process<T>(controller, "application/json", payload: null, action, parameters, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a put method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Put<T>(string controller, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+
+            return Process<T>(controller, "application/json", payload: null, action, parameters, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a delete method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Delete<T>(string controller, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            // Get the reponse
+            return Process<T>(controller, "application/json", payload: null, action, parameters, HttpMethod.Delete, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        /// <summary>
+        /// Execute a get method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Get(string controller, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            return Process<string>(controller, "application/json", payload: null, action, parameters, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a put method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Put(string controller, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+            return Process<string>(controller, "application/json", payload: null, action, parameters, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a post method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Post(string controller, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            // Get the reponse
+            return Process<string>(controller, "application/json", payload: null, action, parameters, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a delete method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Delete(string controller, IDictionary<string, string> parameters, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+
+            // Get the reponse
+            return Process<string>(controller, "application/json", payload: null, action, parameters, HttpMethod.Delete, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        #endregion
+
+        #region without parameters
+        ///// <summary>
+        ///// Execute a post method without header and return a model
+        ///// </summary>
+        ///// <typeparam name="T">type of return</typeparam>
+        ///// <param name="controller">name of the controller</param>
+        ///// <param name="action">name of the action</param>
+        ///// <param name="jsonBody">body in json</param>
+        ///// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        ///// 
+        ///// <returns>Result of the request</returns>
+        //public Task<T> Post<T>(string controller, string jsonBody, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        //{
+
+        //    return Process<T>(controller, "application/json", jsonBody, action, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        //}
+
+        ///// <summary>
+        ///// Execute a get method and return a model
+        ///// </summary>
+        ///// <typeparam name="T">type of return</typeparam>
+        ///// <param name="controller">name of the controller</param>
+        ///// <param name="action">name of the action</param>
+        ///// <param name="jsonBody">body in json</param>
+        ///// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        ///// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        ///// <returns>Result of the request</returns>
+        //public Task<T> Get<T>(string controller, string jsonBody, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        //{
+
+        //    return Process<T>(controller, "application/json", jsonBody, action, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        //}
+        ///// <summary>
+        ///// Execute a put method and return a model
+        ///// </summary>
+        ///// <typeparam name="T">type of return</typeparam>
+        ///// <param name="controller">name of the controller</param>
+        ///// <param name="action">name of the action</param>
+        ///// <param name="jsonBody">body in json</param>
+        ///// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        ///// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        ///// <returns>Result of the request</returns>
+        //public Task<T> Put<T>(string controller, string jsonBody, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        //{
+
+
+        //    return Process<T>(controller, "application/json", jsonBody, action, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        //}
+        ///// <summary>
+        ///// Execute a delete method and return a model
+        ///// </summary>
+        ///// <typeparam name="T">type of return</typeparam>
+        ///// <param name="controller">name of the controller</param>
+        ///// <param name="action">name of the action</param>
+        ///// <param name="jsonBody">body in json</param>
+        ///// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        ///// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        ///// <returns>Result of the request</returns>
+        //public Task<T> Delete<T>(string controller, string jsonBody, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        //{
+
+        //    // Get the reponse
+        //    return Process<T>(controller, "application/json", jsonBody, action, HttpMethod.Delete, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        //}
+
+        ///// <summary>
+        ///// Execute a get method and return a model
+        ///// </summary>
+        ///// <typeparam name="T">type of return</typeparam>
+        ///// <param name="controller">name of the controller</param>
+        ///// <param name="action">name of the action</param>
+        ///// <param name="jsonBody">body in json</param>
+        ///// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        ///// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        ///// <returns>Result of the request</returns>
+        //public Task<string> Get(string controller, string jsonBody, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        //{
+
+        //    return Process<string>(controller, "application/json", jsonBody, action, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        //}
+        ///// <summary>
+        ///// Execute a put method and return a model
+        ///// </summary>
+        ///// <typeparam name="T">type of return</typeparam>
+        ///// <param name="controller">name of the controller</param>
+        ///// <param name="action">name of the action</param>
+        ///// <param name="jsonBody">body in json</param>
+        ///// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        ///// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        ///// <returns>Result of the request</returns>
+        //public Task<string> Put(string controller, string jsonBody, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        //{
+        //    return Process<string>(controller, "application/json", jsonBody, action, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        //}
+        ///// <summary>
+        ///// Execute a post method and return a model
+        ///// </summary>
+        ///// <typeparam name="T">type of return</typeparam>
+        ///// <param name="controller">name of the controller</param>
+        ///// <param name="action">name of the action</param>
+        ///// <param name="jsonBody">body in json</param>
+        ///// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        ///// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        ///// <returns>Result of the request</returns>
+        //public Task<string> Post(string controller, string jsonBody, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        //{
+
+        //    // Get the reponse
+        //    return Process<string>(controller, "application/json", jsonBody, action, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        //}
+        ///// <summary>
+        ///// Execute a delete method and return a model
+        ///// </summary>
+        ///// <typeparam name="T">type of return</typeparam>
+        ///// <param name="controller">name of the controller</param>
+        ///// <param name="action">name of the action</param>
+        ///// <param name="jsonBody">body in json</param>
+        ///// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        ///// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        ///// <returns>Result of the request</returns>
+        //public Task<string> Delete(string controller, string jsonBody, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        //{
+
+        //    // Get the reponse
+        //    return Process<string>(controller, "application/json", jsonBody, action, HttpMethod.Delete, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        //}
+        ///// <summary>
+        ///// Execute a post method without header and return a model
+        ///// </summary>
+        ///// <typeparam name="T">type of return</typeparam>
+        ///// <param name="controller">name of the controller</param>
+        ///// <param name="action">name of the action</param>
+        ///// <param name="httpContent">httpContent</param>
+        ///// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        ///// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        ///// <returns>Result of the request</returns>
+        //public Task<T> Post<T>(string controller, HttpContent httpContent, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        //{
+
+        //    return Process<T>(controller, contentType, httpContent, action, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        //}
+
+        ///// <summary>
+        ///// Execute a get method and return a model
+        ///// </summary>
+        ///// <typeparam name="T">type of return</typeparam>
+        ///// <param name="controller">name of the controller</param>
+        ///// <param name="action">name of the action</param>
+        ///// <param name="httpContent">httpContent</param>
+        ///// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        ///// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        ///// <returns>Result of the request</returns>
+        //public Task<T> Get<T>(string controller, HttpContent httpContent, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        //{
+
+        //    return Process<T>(controller, contentType, httpContent, action, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        //}
+        ///// <summary>
+        ///// Execute a put method and return a model
+        ///// </summary>
+        ///// <typeparam name="T">type of return</typeparam>
+        ///// <param name="controller">name of the controller</param>
+        ///// <param name="action">name of the action</param>
+        ///// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        ///// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        ///// <returns>Result of the request</returns>
+        //public Task<T> Put<T>(string controller, HttpContent httpContent, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        //{
+
+
+        //    return Process<T>(controller, contentType, httpContent, action, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        //}
+        ///// <summary>
+        ///// Execute a delete method and return a model
+        ///// </summary>
+        ///// <typeparam name="T">type of return</typeparam>
+        ///// <param name="controller">name of the controller</param>
+        ///// <param name="action">name of the action</param>
+        ///// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        ///// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        ///// <returns>Result of the request</returns>
+        //public Task<T> Delete<T>(string controller, HttpContent httpContent, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        //{
+
+        //    // Get the reponse
+        //    return Process<T>(controller, contentType, httpContent, action, HttpMethod.Delete, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        //}
+
+        ///// <summary>
+        ///// Execute a get method and return a model
+        ///// </summary>
+        ///// <typeparam name="T">type of return</typeparam>
+        ///// <param name="controller">name of the controller</param>
+        ///// <param name="action">name of the action</param>
+        ///// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        ///// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        ///// <returns>Result of the request</returns>
+        //public Task<string> Get(string controller, HttpContent httpContent, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        //{
+
+        //    return Process<string>(controller, contentType, httpContent, action, HttpMethod.Get, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        //}
+        ///// <summary>
+        ///// Execute a put method and return a model
+        ///// </summary>
+        ///// <typeparam name="T">type of return</typeparam>
+        ///// <param name="controller">name of the controller</param>
+        ///// <param name="action">name of the action</param>
+        ///// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        ///// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        ///// <returns>Result of the request</returns>
+        //public Task<string> Put(string controller, HttpContent httpContent, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        //{
+        //    return Process<string>(controller, contentType, httpContent, action, HttpMethod.Put, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        //}
+        ///// <summary>
+        ///// Execute a post method and return a model
+        ///// </summary>
+        ///// <typeparam name="T">type of return</typeparam>
+        ///// <param name="controller">name of the controller</param>
+        ///// <param name="action">name of the action</param>
+        ///// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        ///// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        ///// <returns>Result of the request</returns>
+        //public Task<string> Post(string controller, HttpContent httpContent, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        //{
+
+        //    // Get the reponse
+        //    return Process<string>(controller, contentType, httpContent, action, HttpMethod.Post, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        //}
+        ///// <summary>
+        ///// Execute a delete method and return a model
+        ///// </summary>
+        ///// <typeparam name="T">type of return</typeparam>
+        ///// <param name="controller">name of the controller</param>
+        ///// <param name="action">name of the action</param>
+        ///// <param name="jsonBody">body in json</param>
+        ///// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        ///// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        ///// <returns>Result of the request</returns>
+        //public Task<string> Delete(string controller, HttpContent httpContent, string action = null, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null, string contentType = "application/json")
+        //{
+
+        //    // Get the reponse
+        //    return Process<string>(controller, contentType, httpContent, action, HttpMethod.Delete, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        //}
+
+        #endregion
+        #endregion
+
+        /// <summary>
+        /// Get get a response of a request using a string content
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller"></param>
+        /// <param name="payload">string payload</param>
+        /// <param name="action"></param>
+        /// <param name="httpMethod"></param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>response of the method in the form of a model</returns>
+        private async Task<T> Process<T>(string controller, string contentType, string payload, string action, HttpMethod httpMethod, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+            try
+            {
+                // 
+                string methodUrl = BuildUrl(controller, action);
+
+                // Build the request
+                return await ProcessRequest<T>(contentType, payload, httpMethod, unSuccessCallback: unSuccessCallback, singleUseHeaders, methodUrl);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("[Issue Handler]: " + ex.Message);
+            }
+            
+
+
+        }
 
         /// <summary>
         /// Get get a response of a path request using a string content
@@ -578,6 +1362,29 @@ namespace CustardApi.Objects
             
 
 
+        }
+
+        /// <summary>
+        /// Get get a response of a request using a HttpContent
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller"></param>
+        /// <param name="httpContent"></param>
+        /// <param name="action"></param>
+        /// <param name="httpMethod"></param>
+        /// <returns>response of the method in the form of a model</returns>
+        private async Task<T> Process<T>(string controller, string contentType, HttpContent httpContent, string action, HttpMethod httpMethod, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        {
+            try
+            {
+                string methodUrl = BuildUrl(controller, action);
+
+                return await ProcessRequest<T>(contentType: contentType, httpContent: httpContent, httpMethod: httpMethod, unSuccessCallback: unSuccessCallback, singleUseHeaders: singleUseHeaders, methodUrl: methodUrl);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("[Issue Handler]: " + ex.Message);
+            }
         }
 
         /// <summary>
@@ -658,9 +1465,12 @@ namespace CustardApi.Objects
         /// <param name="controller"></param>
         /// <param name="action"></param>
         /// <param name="parameters"></param>
-        /// <returns></returns>
-        private string BuildUrl(string controller, string action, string[] parameters)
+        /// <returns>Full url of the request</returns>
+        private string BuildUrl(string controller, string action, string[] parameters= null)
         {
+            if (parameters == null)
+                return _baseUrl + controller;
+
             // Build the url
             string methodUrl = _baseUrl + controller + (string.IsNullOrEmpty(action) ? "" : "/" + action);
 

--- a/CustardApi/Objects/Service.cs
+++ b/CustardApi/Objects/Service.cs
@@ -1,8 +1,10 @@
 ﻿
+using CustardApi.Tools;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Diagnostics;
 using System.Linq;
 using System.Net;
@@ -472,7 +474,7 @@ namespace CustardApi.Objects
 
         }
         /// <summary>
-        ///  Method to create a url with the given parameters
+        ///  Method to create a url with the given path parameters
         /// </summary>
         /// <param name="parameters">List of parameters</param>
         /// <param name="initialUrl">The base url</param>
@@ -481,13 +483,23 @@ namespace CustardApi.Objects
         {
             if (parameters != null)
             {
-                // For each parameters
-                foreach (string parameter in parameters)
-                {
-                    // Add the parameter to the url
-                    initialUrl += $"/{parameter}";
+                initialUrl = UrlTool.BuildPathUrl(parameters, initialUrl);
+            }
 
-                }
+            return initialUrl;
+        }
+
+        /// <summary>
+        ///  Method to create a url with the given query parameters
+        /// </summary>
+        /// <param name="parameters">List of parameters</param>
+        /// <param name="initialUrl">The base url</param>
+        /// <returns>The url with all the parameters</returns>
+        private static string CreateUrl(Dictionary<string,string> parameters, string initialUrl)
+        {
+            if (parameters != null)
+            {
+                initialUrl = UrlTool.BuildQueryUrl(parameters, initialUrl);
             }
 
             return initialUrl;

--- a/CustardApi/Tools/UrlTool.cs
+++ b/CustardApi/Tools/UrlTool.cs
@@ -27,7 +27,7 @@ namespace CustardApi.Tools
         /// <param name="parameters">parameters you want in the URL</param>
         /// <param name="initialUrl">url you already have</param>
         /// <returns>new url with all the parameters</returns>
-        public static string BuildQueryUrl(Dictionary<string, string> parameters, string initialUrl)
+        public static string BuildQueryUrl(IDictionary<string, string> parameters, string initialUrl)
         {
             // Add the initiator
             initialUrl += "?";

--- a/CustardApi/Tools/UrlTool.cs
+++ b/CustardApi/Tools/UrlTool.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace CustardApi.Tools
+{
+    public static class UrlTool
+    {
+        /// <summary>
+        /// Build the url using parameters and initial url using a Path patern
+        /// </summary>
+        /// <param name="parameters">parameters you want in the URL</param>
+        /// <param name="initialUrl">url you already have</param>
+        /// <returns>new url with all the parameters</returns>
+        public static string BuildPathUrl(string[] parameters, string initialUrl)
+        {
+            // For each parameters
+            for (int i = 0; i < parameters.Count(); i++)
+                // Add the parameter to the url
+                initialUrl += $"/{parameters[i]}";
+            return initialUrl;
+        }
+        /// <summary>
+        /// Build the url using parameters and initial url using a Query patern
+        /// </summary>
+        /// <param name="parameters">parameters you want in the URL</param>
+        /// <param name="initialUrl">url you already have</param>
+        /// <returns>new url with all the parameters</returns>
+        public static string BuildQueryUrl(Dictionary<string, string> parameters, string initialUrl)
+        {
+            // Add the initiator
+            initialUrl += "?";
+
+            // For each parameters
+            for (int i = 0; i < parameters.Count(); ++i)
+            {
+                // Get the parameter 
+                KeyValuePair<string, string> param = parameters.ElementAt(i);
+
+                if (i == parameters.Count() - 1)
+                    // Add the last parameter 
+                    initialUrl += $"{param.Key}={param.Value}";
+                else
+                    // Add the parameter to the url while keeping in mind that another parameter will follow
+                    initialUrl += $"{param.Key}={param.Value}&";
+            }
+
+            return initialUrl;
+        }
+    }
+}

--- a/NUnitTestCustardApi/ModelsTest/ReqresUser.cs
+++ b/NUnitTestCustardApi/ModelsTest/ReqresUser.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NUnitTestCustardApi.ModelsTest
+{
+    public class ReqresUser
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+        [JsonProperty("job")]
+        public string Job { get; set; }
+    }
+}

--- a/NUnitTestCustardApi/ModelsTest/ReqresUserResponse.cs
+++ b/NUnitTestCustardApi/ModelsTest/ReqresUserResponse.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace NUnitTestCustardApi.ModelsTest
+{
+    public class ReqresUserResponse : ReqresUser
+    {
+        
+        [JsonProperty("id")]
+        public string Id { get; set; }
+        [JsonProperty("createdAt")]
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/NUnitTestCustardApi/NUnitTestCustardApi.csproj
+++ b/NUnitTestCustardApi/NUnitTestCustardApi.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="nunit" Version="4.0.1" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/NUnitTestCustardApi/Objects/ServiceTest.cs
+++ b/NUnitTestCustardApi/Objects/ServiceTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+﻿
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -10,6 +10,7 @@ using System.Collections.ObjectModel;
 using System.Net;
 using System.Reflection.PortableExecutable;
 using Newtonsoft.Json;
+using NUnit.Framework;
 
 namespace NUnitTestCustardApi
 {

--- a/NUnitTestCustardApi/Objects/ServiceTest.cs
+++ b/NUnitTestCustardApi/Objects/ServiceTest.cs
@@ -408,6 +408,26 @@ namespace NUnitTestCustardApi
         [Test]
         public async Task PutMethodWithPathParameters()
         {
+            // Arrange
+            var userToCreate = new ReqresUser
+            {
+                Name = "morpheus",
+                Job = "leader"
+            };
+            string action = "users";
+            string controller = "api";
+            string[] param = { "2" };
+
+            // Act
+            var result = await _serviceReqres.Put<ReqresUser>(controller: controller, action: action, jsonBody: JsonConvert.SerializeObject(userToCreate), parameters: param );
+            
+            // Assert
+            Console.WriteLine(JsonConvert.SerializeObject(result));
+            Assert.IsNotNull(result);
+        }
+        [Test]
+        public async Task DeleteMethodWithPathParameters()
+        {
             // Arrage
             // Act
             // Assert

--- a/NUnitTestCustardApi/Objects/ServiceTest.cs
+++ b/NUnitTestCustardApi/Objects/ServiceTest.cs
@@ -429,8 +429,19 @@ namespace NUnitTestCustardApi
         public async Task DeleteMethodWithPathParameters()
         {
             // Arrage
+            string action = "users";
+            string controller = "api";
+            string[] param = { "2" };
+
             // Act
+            var result = await _serviceReqres.Delete(controller: controller, action: action, parameters: param, unSuccessCallback: (err) =>
+            {
+                Assert.Fail(err.ReasonPhrase);
+            });
+
             // Assert
+            Console.WriteLine(JsonConvert.SerializeObject(result));
+            Assert.IsNotNull(result);
         }
     }
 }

--- a/NUnitTestCustardApi/Objects/ServiceTest.cs
+++ b/NUnitTestCustardApi/Objects/ServiceTest.cs
@@ -19,13 +19,15 @@ namespace NUnitTestCustardApi
         private static Service _service;
         private Service _serviceRick;
         private Service _serviceWord;
+        private Service _serviceReqres;
 
         [SetUp]
         public void Setup()
         {
             _service = new Service("api.gamhub.io", sslCertificate: true);
-            _serviceRick = new Service("rickandmortyapi.com/api", sslCertificate: true);
+            _serviceRick = new Service("rickandmortyapi.com", sslCertificate: true);
             _serviceWord = new Service("random-word-api.herokuapp.com", sslCertificate: true);
+            _serviceReqres = new Service("reqres.in", sslCertificate: true);
         }
 
         // Construtor
@@ -352,8 +354,8 @@ namespace NUnitTestCustardApi
             // Arrange
             string language = "en";
             int wordLength = 5;
+            string controller = "word";
 
-            string action = "word";
             Dictionary<string, string> parameters = new Dictionary<string, string>
             {
                 { "length", $"{wordLength}" },
@@ -361,13 +363,54 @@ namespace NUnitTestCustardApi
             };
 
             // Act
-            string result = await _serviceWord.Get(action,jsonBody: null, parameters: parameters);
+            string result = await _serviceWord.Get(controller, jsonBody: null, parameters: parameters);
 
 
             // Assert
             Console.WriteLine(result);
             Assert.IsTrue(!string.IsNullOrEmpty(result));
 
+        }
+        [Test]
+        public async Task GetMethodWithPathParameters()
+        {
+            // Arrage
+            string action = "users";
+            string controller = "api";
+            string[] param = { "2" };
+           
+
+            // Act
+            var resultStr = await _serviceReqres.Get(controller: controller, action: action,parameters: param);
+            // Assert
+            Console.WriteLine(_serviceReqres.LastCall);
+            Assert.IsNotNull(resultStr);
+        }
+        [Test]
+        public async Task PostMethod()
+        {
+            // Arrange
+            var userToCreate = new ReqresUser
+            {
+                Name = "morpheus",
+                Job = "leader"
+            };
+            string action = "users";
+            string controller = "api";
+
+            // Act
+            var result = await _serviceReqres.Post<ReqresUser>(controller: controller, action: action, jsonBody: JsonConvert.SerializeObject(userToCreate) );
+            
+            // Assert
+            Console.WriteLine(JsonConvert.SerializeObject(result));
+            Assert.IsNotNull(result);
+        }
+        [Test]
+        public async Task PutMethodWithPathParameters()
+        {
+            // Arrage
+            // Act
+            // Assert
         }
     }
 }

--- a/NUnitTestCustardApi/Objects/ServiceTest.cs
+++ b/NUnitTestCustardApi/Objects/ServiceTest.cs
@@ -17,19 +17,17 @@ namespace NUnitTestCustardApi
     class ServiceTest
     {
         private static Service _service;
+        private Service _serviceRick;
+        private Service _serviceWord;
 
         [SetUp]
         public void Setup()
         {
-            _service = new Service("api.gamhub.io", sslCertificate: true) ;
+            _service = new Service("api.gamhub.io", sslCertificate: true);
+            _serviceRick = new Service("rickandmortyapi.com/api", sslCertificate: true);
+            _serviceWord = new Service("random-word-api.herokuapp.com", sslCertificate: true);
         }
-        [Test]
-        public async Task LotusAiLogin()
-        {
-            //string body = $"{{ \"email\": \"{ _email}\", \"password\": \"{ _password }\" }}";
-            await _service.Post(action: "authenticate", controller: "authenticateuserbyemail", jsonBody: "{ \"email\": \"jason+mobiletest1@lotusai.co\", \"password\": \"u1oX9es6IOIf\" }");
-            Assert.Pass();
-        }
+
         // Construtor
         //
         // Without SSL certificate
@@ -83,7 +81,7 @@ namespace NUnitTestCustardApi
             Service constructorNonSSl;
 
             // Act
-            constructorNonSSl = new Service("localhost",2020);
+            constructorNonSSl = new Service("localhost", 2020);
 
             // Assert
             Assert.AreEqual("http://localhost:2020/", constructorNonSSl.BaseUrl);
@@ -106,7 +104,7 @@ namespace NUnitTestCustardApi
             string body = "{ \"email\": \"brice.friha@outlook.com\", \"password\": \"pwd\" }";
 
             // Act
-            User actualResult = await _service.Post<User>( "users", jsonBody: body, "authenticate");
+            User actualResult = await _service.Post<User>("users", jsonBody: body, "authenticate");
 
             _service.Dispose();
 
@@ -153,12 +151,12 @@ namespace NUnitTestCustardApi
 
 
             // Act
-            Collection<Article> actualResult = await _service.Get<Collection<Article>>("feeds");
+            Collection<Article> actualResult = await _service.Get<Collection<Article>>("feeds", jsonBody: null);
 
             _service.Dispose();
 
             // Assert
-            Assert.Greater(actualResult?.Count,0 );
+            Assert.Greater(actualResult?.Count, 0);
         }
         // Post Method
         // With a body a token but no params 
@@ -200,7 +198,7 @@ namespace NUnitTestCustardApi
 
 
             // Act
-            Collection<Todolist> actualResult = await _service.Get<Collection<Todolist>>("todolists");
+            Collection<Todolist> actualResult = await _service.Get<Collection<Todolist>>("todolists", jsonBody: null);
 
             _service.Dispose();
 
@@ -214,8 +212,8 @@ namespace NUnitTestCustardApi
             // Arrange
             Todolist Expectation = new Todolist
             {
-                    Title = "Unit test",
-                    User = "5ee24ee3796d9519fcc1b25d"
+                Title = "Unit test",
+                User = "5ee24ee3796d9519fcc1b25d"
             };
 
             string body = "{ \"title\": \"Workout\" }";
@@ -226,7 +224,7 @@ namespace NUnitTestCustardApi
 
 
             // Act
-            Todolist actualResult = await _service.Put<Todolist>("todolists", "rename", body, parameters);
+            Todolist actualResult = await _service.Put<Todolist>("todolists", "rename", parameters, body );
 
             _service.Dispose();
 
@@ -251,13 +249,13 @@ namespace NUnitTestCustardApi
             ///
             /// Create the item that we gonna delete later on
             string body = "{ \"title\": \"Workout\" }";
-            Todolist itemToDelete = await _service.Post<Todolist>("todolists", "create", body);
+            Todolist itemToDelete = await _service.Post<Todolist>("todolists", body, "create");
             /// 
             /// Put the id as parameters of the delete method
             string[] parameters = { itemToDelete.Id };
 
             // Act
-            DeleteCode actualResult = await _service.Delete<DeleteCode>("todolists", parameters: parameters);
+            DeleteCode actualResult = await _service.Delete<DeleteCode>(controller:"todolists", parameters: parameters);
 
             _service.Dispose();
 
@@ -275,7 +273,7 @@ namespace NUnitTestCustardApi
             string body = "{ \"email\": \"brice.friha@outlook.com\", \"password\": \"pwd\" }";
 
             // Act
-            string actualResult = await _service.Post( "users", jsonBody: body, "authenticate");
+            string actualResult = await _service.Post("users", body, "authenticate",(e) => { });
 
             _service.Dispose();
 
@@ -293,7 +291,7 @@ namespace NUnitTestCustardApi
 
 
             // Act
-            string actualResult = await _service.Get ( "todolists");
+            string actualResult = await _service.Get("todolists", jsonBody: null);
 
             _service.Dispose();
             // Assert
@@ -313,7 +311,7 @@ namespace NUnitTestCustardApi
 
 
             // Act
-            string actualResult = await _service.Put ("todolists", jsonBody: body, "rename", parameters: parameters);
+            string actualResult = await _service.Put("todolists", "rename", parameters, body);
 
             _service.Dispose();
             // Assert
@@ -333,20 +331,43 @@ namespace NUnitTestCustardApi
             /// Create the item that we gonna delete later on
             string body = "{ \"title\": \"Workout\" }";
 
-            Todolist itemToDelete = await _service.Post<Todolist>("todolists", "create", body);
+            Todolist itemToDelete = await _service.Post<Todolist>("todolists", body, "create");
 
             /// 
             /// Put the id as parameters of the delete method
             string[] parameters = { itemToDelete.Id };
 
             // Act
-            string actualResult = await _service.Delete("todolists", jsonBody: null, parameters: parameters) ;
+            string actualResult = await _service.Delete("todolists", jsonBody: null, parameters: parameters);
 
             _service.Dispose();
 
             // Assert
             Console.WriteLine(actualResult);
             Assert.Pass();
+        }
+        [Test]
+        public async Task GetMethodWithQueryParameters()
+        {
+            // Arrange
+            string language = "en";
+            int wordLength = 5;
+
+            string action = "word";
+            Dictionary<string, string> parameters = new Dictionary<string, string>
+            {
+                { "length", $"{wordLength}" },
+                { "lang", language }
+            };
+
+            // Act
+            string result = await _serviceWord.Get(action,jsonBody: null, parameters: parameters);
+
+
+            // Assert
+            Console.WriteLine(result);
+            Assert.IsTrue(!string.IsNullOrEmpty(result));
+
         }
     }
 }


### PR DESCRIPTION
Per #10, the changes are aimed at supporting supporting query parameters.

### Changes
- Simplify the code to make it more reusable
- Introduction of overloads for Service `Post()` `Get()` `Put()` and `Delete()` to have a ``IDictionary<string,string>`` parameters 
- Addition of a new unit test case

### Client usage

On top of the regular usage, to use query parameters in your request, you must set a ``IDictionary<string, string>`` listing all the parameters and add it to your request.
Here's an example:
``` Csharp
// Arrange
string language = "en";
int wordLength = 5;
string controller = "word";

Dictionary<string, string> parameters = new Dictionary<string, string>
{
    { "length", $"{wordLength}" },
    { "lang", language }
};

// Act
string result = await _serviceWord.Get(controller, jsonBody: null, parameters: parameters);
```

Closes #10 