### PR TITLE
Update the documentation for v0.3.3

### DIFF
--- a/CustardApi/CustardApi.csproj
+++ b/CustardApi/CustardApi.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
 	  <LangVersion>9.0</LangVersion>
-    <Version>0.3.2</Version>
+    <Version>0.3.3</Version>
     <Authors>Brice Friha</Authors>
     <Product>Custard</Product>
     <PackageId>Custard</PackageId>
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <VersionMajor>0</VersionMajor>
     <VersionMinor>3</VersionMinor>
-    <VersionBuild>2</VersionBuild>
+    <VersionBuild>3</VersionBuild>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Documentations/Doc_0.3.2.md
+++ b/Documentations/Doc_0.3.2.md
@@ -1,0 +1,124 @@
+<p align="center" class="container" >
+  <img width="200px" src="https://user-images.githubusercontent.com/37577669/85275198-47b3ca00-b480-11ea-8273-d990295416a7.png" />
+  
+</p>
+
+# What's Custard? 
+[![NuGet](https://img.shields.io/nuget/v/Custard.svg?style=flat)](https://www.nuget.org/packages/Custard/)
+
+Custard is a .NET standard plugin to call web APIs intuitively. 😁
+
+
+
+# Documentation 📄
+## Installation
+- Package manager
+  ```Bash
+  Install-Package Custard -Version 0.3.2
+  ```
+- .NET CLI
+  ```Bash
+  dotnet add package Custard --version 0.3.2
+  ```
+## Custard.Service
+- ### Instantiate a service object:
+
+```C#
+Service yourService = new Service(string host, int port = 80, bool sslCertificate = false); 
+```
+- ### Create headers
+```C#
+yourService.RequestHeaders.Add("Hearder", "Value "); // Do this for every headers
+```
+- ### Call a POST method
+
+  **Parameters**:
+
+  | Name      | Type     | Required     |
+  | :------------- | :----------: | -----------: |
+  |  *controller* | string   | ✔    |
+  |  *action* | string   |  ❌   |
+  |  *headers* | IDictionary<string, string>   |  ❌  |
+  |  *jsonBody* | string   |   ❌  |
+  |  *parameters* | string[]   |   ❌  |
+
+
+  **Usage**:
+  - To return a string:
+    ```C#
+    yourService.Post (controller, action, headers, jsonBody, parameters);
+    ```
+  - To return a model (T is the model):
+    ```C#
+    yourService.Post<T> (controller, action, headers, jsonBody, parameters);
+    ```
+- ### Call a PUT method
+
+  **Parameters**:
+
+  | Name      | Type     | Required     |
+  | :------------- | :----------: | -----------: |
+  |  *controller* | string   | ✔    |
+  |  *action* | string   |  ❌   |
+  |  *headers* | IDictionary<string, string>   |  ❌  |
+  |  *jsonBody* | string   |   ❌  |
+  |  *parameters* | string[]   |   ❌  |
+
+
+  **Usage**:
+  - To return a string:
+    ```C#
+    yourService.Put (controller, action, headers, jsonBody, parameters);
+    ```
+  - To return a model (T is the model):
+    ```C#
+    yourService.Put<T> (controller, action, headers, jsonBody, parameters);
+    ```
+
+- ### Call a GET method
+
+  **Parameters**:
+
+  | Name      | Type     | Required     |
+  | :------------- | :----------: | -----------: |
+  |  *controller* | string   | ✔    |
+  |  *action* | string   |  ❌   |
+  |  *headers* | IDictionary<string, string>   |  ❌  |
+  |  *jsonBody* | string   |   ❌  |
+  |  *parameters* | string[]   |   ❌  |
+
+
+  **Usage**:
+  - To return a string:
+  ```C#
+  yourService.Get (controller, action, headers, jsonBody, parameters);
+  ```
+  - To return a model (T is the model):
+  ```C#
+  yourService.Get<T> (controller, action, headers, jsonBody, parameters);
+  ```
+
+
+> ⚠ If you want to return a model the HTTP response body has to be in JSON format
+
+
+  **I didn't finish the documentation, that's why it's so ugly. Sorry about that 😁**
+
+- ### Callback Error
+  If needed, you can add a callback if the request faces an HTTP error. This will work with any method mentioned above. This will allow you to do an handle the error       more easily.
+  Here's how it works:
+  ``` Csharp
+  var actualResult = await yourService.Get("todolists", headers: headers, callbackError: (code) => 
+            {
+                switch (code):
+                          case HttpStatusCode.NotFound: 
+                                    // do something
+                                break;
+                           case HttpStatusCode.BadRequest: 
+                                    // do something else
+                                break;
+                          // .. etc
+            });
+  ```
+  - **code**: the error status code (HttpStatusCode).
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Brice FRIHA
+Copyright (c) 2024 Brice FRIHA
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ yourService.RequestHeaders.Add("Hearder", "Value "); // Do this for every header
 
   | Name      | Type     | Required     |
   | :------------- | :----------: | -----------: |
-  |  *controller* | string   | ✔    |
-  |  *action* | string   |  ❌   |
-  |  *headers* | IDictionary<string, string>   |  ❌  |
-  |  *jsonBody* | string   |   ❌  |
-  |  *parameters* | string[] / IDictonary<string,string>   |   ❌  |
+  |  *controller* | `string`   | ✔    |
+  |  *action* | `string`   |  ❌   |
+  |  *headers* | `IDictionary<string, string>`   |  ❌  |
+  |  *jsonBody* | `string`   |   ❌  |
+  |  *parameters* | `string[] / IDictonary<string,string>`   |   ❌  |
 
 
   **Usage**:
@@ -63,7 +63,7 @@ yourService.RequestHeaders.Add("Hearder", "Value "); // Do this for every header
   |  *action* | `string`   |  ❌   |
   |  *headers* | `IDictionary<string, string>`   |  ❌  |
   |  *jsonBody* | `string`   |   ❌  |
-  |  *parameters* | `string[]` / IDictonary<string,string>   |   ❌  |
+  |  *parameters* | `string[] / IDictonary<string,string>`   |   ❌  |
 
 
   **Usage**:
@@ -82,11 +82,11 @@ yourService.RequestHeaders.Add("Hearder", "Value "); // Do this for every header
 
   | Name      | Type     | Required     |
   | :------------- | :----------: | -----------: |
-  |  *controller* | string   | ✔    |
-  |  *action* | string   |  ❌   |
-  |  *headers* | IDictionary<string, string>   |  ❌  |
-  |  *jsonBody* | string   |   ❌  |
-  |  *parameters* | string[] / IDictonary<string,string>   |   ❌  |
+  |  *controller* | `string`   | ✔    |
+  |  *action* | `string`   |  ❌   |
+  |  *headers* | `IDictionary<string, string>`   |  ❌  |
+  |  *jsonBody* | `string`   |   ❌  |
+  |  *parameters* | `string[] / IDictonary<string,string>`   |   ❌  |
 
 
   **Usage**:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 
 Custard is a .NET standard plugin to call web APIs intuitively. 😁
 
-
+Fully compatible with:
+- **.NET MAUI**
+- **Xamarin Forms**
 
 # Documentation 📄
 ## Installation

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Custard is a .NET standard plugin to call web APIs intuitively. 😁
 ## Installation
 - Package manager
   ```Bash
-  Install-Package Custard -Version 0.3.2
+  Install-Package Custard -Version 0.3.3
   ```
 - .NET CLI
   ```Bash
-  dotnet add package Custard --version 0.3.2
+  dotnet add package Custard --version 0.3.3
   ```
 ## Custard.Service
 - ### Instantiate a service object:
@@ -30,6 +30,7 @@ Service yourService = new Service(string host, int port = 80, bool sslCertificat
 ```C#
 yourService.RequestHeaders.Add("Hearder", "Value "); // Do this for every headers
 ```
+
 - ### Call a POST method
 
   **Parameters**:
@@ -40,7 +41,7 @@ yourService.RequestHeaders.Add("Hearder", "Value "); // Do this for every header
   |  *action* | string   |  ❌   |
   |  *headers* | IDictionary<string, string>   |  ❌  |
   |  *jsonBody* | string   |   ❌  |
-  |  *parameters* | string[]   |   ❌  |
+  |  *parameters* | string[] / IDictonary<string,string>   |   ❌  |
 
 
   **Usage**:
@@ -58,11 +59,11 @@ yourService.RequestHeaders.Add("Hearder", "Value "); // Do this for every header
 
   | Name      | Type     | Required     |
   | :------------- | :----------: | -----------: |
-  |  *controller* | string   | ✔    |
-  |  *action* | string   |  ❌   |
-  |  *headers* | IDictionary<string, string>   |  ❌  |
-  |  *jsonBody* | string   |   ❌  |
-  |  *parameters* | string[]   |   ❌  |
+  |  *controller* | `string`   | ✔    |
+  |  *action* | `string`   |  ❌   |
+  |  *headers* | `IDictionary<string, string>`   |  ❌  |
+  |  *jsonBody* | `string`   |   ❌  |
+  |  *parameters* | `string[]` / IDictonary<string,string>   |   ❌  |
 
 
   **Usage**:
@@ -85,7 +86,7 @@ yourService.RequestHeaders.Add("Hearder", "Value "); // Do this for every header
   |  *action* | string   |  ❌   |
   |  *headers* | IDictionary<string, string>   |  ❌  |
   |  *jsonBody* | string   |   ❌  |
-  |  *parameters* | string[]   |   ❌  |
+  |  *parameters* | string[] / IDictonary<string,string>   |   ❌  |
 
 
   **Usage**:
@@ -98,26 +99,52 @@ yourService.RequestHeaders.Add("Hearder", "Value "); // Do this for every header
   yourService.Get<T> (controller, action, headers, jsonBody, parameters);
   ```
 
+## Passing Parameters to your requests
+Custard now supports two types of parameters:
+- Path parameters
+- Query parameters
 
-> ⚠ If you want to return a model the HTTP response body has to be in JSON format
+### Path parameters
+To pass path parameters to your requests, you have to pass them as `string[]`:
+
+**E.g**: for `/users/api/2/3/4` we would use:
+``` C#
+string action = "users";
+string controller = "api";
+string[] param = { "2", "3", "4" };
+           
+var resultStr = await yourService.Get(controller: controller, action: action, parameters: param);
+```
+### Path parameters
+To pass query parameters to your requests, you have to pass them as `Dictionary<string, string>`:
+
+**E.g**: for `/users/api?two=2&three=3&four=4` we would use:
+``` C#
+string action = "users";
+string controller = "api";
+
+Dictionary<string, string> param = new Dictionary<string, string>
+{
+    { "two", "2" },
+    { "three", "3" },
+    { "four", "4" }
+};
+           
+var resultStr = await yourService.Get(controller: controller, action: action, parameters: param);
+```
+
+> ⚠ If you want to return a model, the HTTP response body has to be in JSON format
 
 
-  **I didn't finish the documentation, that's why it's so ugly. Sorry about that 😁**
+  **I didn't finish the documentation. That's why it's so ugly. Sorry about that 😁**
 
 - ### Callback Error
   If needed, you can add a callback if the request faces an HTTP error. This will work with any method mentioned above. This will allow you to do an handle the error       more easily.
   Here's how it works:
   ``` Csharp
-  var actualResult = await yourService.Get("todolists", headers: headers, callbackError: (code) => 
+  var actualResult = await yourService.Get("todolists", headers: headers, callbackError: (err) => 
             {
-                switch (code):
-                          case HttpStatusCode.NotFound: 
-                                    // do something
-                                break;
-                           case HttpStatusCode.BadRequest: 
-                                    // do something else
-                                break;
-                          // .. etc
+                
             });
   ```
   - **code**: the error status code (HttpStatusCode).


### PR DESCRIPTION
Documentation that follows the release of Custard API v0.3.3

### Changes

- Changing version number in the command line
- Adding `IDictonary<string, string>` in the parameter fields of all calls
- Adding documentation for both query and path parameters