### PR TITLE
Enhancement - #22 add option to object payload in request

### DIFF
--- a/CustardApi/Objects/Service.cs
+++ b/CustardApi/Objects/Service.cs
@@ -1107,7 +1107,7 @@ namespace CustardApi.Objects
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller">name of the controller</param>
         /// <param name="action">name of the action</param>
-        /// <param name="jsonBody">body in json</param>
+        /// <param name="payload">object payload</param>
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// 
         /// <returns>Result of the request</returns>
@@ -1129,7 +1129,7 @@ namespace CustardApi.Objects
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller">name of the controller</param>
         /// <param name="action">name of the action</param>
-        /// <param name="jsonBody">body in json</param>
+        /// <param name="payload">object payload</param>
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
@@ -1150,7 +1150,7 @@ namespace CustardApi.Objects
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller">name of the controller</param>
         /// <param name="action">name of the action</param>
-        /// <param name="jsonBody">body in json</param>
+        /// <param name="payload">object payload</param>
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
@@ -1195,7 +1195,7 @@ namespace CustardApi.Objects
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller">name of the controller</param>
         /// <param name="action">name of the action</param>
-        /// <param name="jsonBody">body in json</param>
+        /// <param name="payload">object payload</param>
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
@@ -1236,7 +1236,7 @@ namespace CustardApi.Objects
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller">name of the controller</param>
         /// <param name="action">name of the action</param>
-        /// <param name="jsonBody">body in json</param>
+        /// <param name="payload">object payload</param>
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
@@ -1258,7 +1258,7 @@ namespace CustardApi.Objects
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller">name of the controller</param>
         /// <param name="action">name of the action</param>
-        /// <param name="jsonBody">body in json</param>
+        /// <param name="payload">object payload</param>
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
@@ -1284,7 +1284,7 @@ namespace CustardApi.Objects
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller">name of the controller</param>
         /// <param name="action">name of the action</param>
-        /// <param name="jsonBody">body in json</param>
+        /// <param name="payload">object payload</param>
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// 
         /// <returns>Result of the request</returns>
@@ -1306,7 +1306,7 @@ namespace CustardApi.Objects
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller">name of the controller</param>
         /// <param name="action">name of the action</param>
-        /// <param name="jsonBody">body in json</param>
+        /// <param name="payload">object payload</param>
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
@@ -1349,7 +1349,7 @@ namespace CustardApi.Objects
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller">name of the controller</param>
         /// <param name="action">name of the action</param>
-        /// <param name="jsonBody">body in json</param>
+        /// <param name="payload">object payload</param>
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
@@ -1373,17 +1373,17 @@ namespace CustardApi.Objects
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller">name of the controller</param>
         /// <param name="action">name of the action</param>
-        /// <param name="jsonBody">body in json</param>
+        /// <param name="payload">object payload</param>
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
         public Task<string> Get(string controller,
-                                IDictionary<string, string> parameters,
+                                 IDictionary<string, string> parameters,
                                  object payload,
-                                string action = null,
-                                Action<HttpResponseMessage> unSuccessCallback = null,
-                                IDictionary<string, string> singleUseHeaders = null,
-                                CancellationToken cancellationToken = default)
+                                 string action = null,
+                                 Action<HttpResponseMessage> unSuccessCallback = null,
+                                 IDictionary<string, string> singleUseHeaders = null,
+                                 CancellationToken cancellationToken = default)
         {
 
             return Process<string>(controller, "application/json", JsonConvert.SerializeObject(payload), action, parameters, HttpMethod.Get, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
@@ -1394,17 +1394,17 @@ namespace CustardApi.Objects
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller">name of the controller</param>
         /// <param name="action">name of the action</param>
-        /// <param name="jsonBody">body in json</param>
+        /// <param name="payload">object payload</param>
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
         public Task<string> Put(string controller,
-                                IDictionary<string, string> parameters,
+                                 IDictionary<string, string> parameters,
                                  object payload,
-                                string action = null,
-                                Action<HttpResponseMessage> unSuccessCallback = null,
-                                IDictionary<string, string> singleUseHeaders = null,
-                                CancellationToken cancellationToken = default)
+                                 string action = null,
+                                 Action<HttpResponseMessage> unSuccessCallback = null,
+                                 IDictionary<string, string> singleUseHeaders = null,
+                                 CancellationToken cancellationToken = default)
         {
             return Process<string>(controller, "application/json", JsonConvert.SerializeObject(payload), action, parameters, HttpMethod.Put, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
         }
@@ -1414,7 +1414,7 @@ namespace CustardApi.Objects
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller">name of the controller</param>
         /// <param name="action">name of the action</param>
-        /// <param name="jsonBody">body in json</param>
+        /// <param name="payload">object payload</param>
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
@@ -1436,7 +1436,7 @@ namespace CustardApi.Objects
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller">name of the controller</param>
         /// <param name="action">name of the action</param>
-        /// <param name="jsonBody">body in json</param>
+        /// <param name="payload">object payload</param>
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
@@ -1462,7 +1462,7 @@ namespace CustardApi.Objects
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller">name of the controller</param>
         /// <param name="action">name of the action</param>
-        /// <param name="jsonBody">body in json</param>
+        /// <param name="payload">object payload</param>
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// 
         /// <returns>Result of the request</returns>
@@ -1483,7 +1483,7 @@ namespace CustardApi.Objects
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller">name of the controller</param>
         /// <param name="action">name of the action</param>
-        /// <param name="jsonBody">body in json</param>
+        /// <param name="payload">object payload</param>
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
@@ -1524,7 +1524,7 @@ namespace CustardApi.Objects
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller">name of the controller</param>
         /// <param name="action">name of the action</param>
-        /// <param name="jsonBody">body in json</param>
+        /// <param name="payload">object payload</param>
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
@@ -1546,7 +1546,7 @@ namespace CustardApi.Objects
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller">name of the controller</param>
         /// <param name="action">name of the action</param>
-        /// <param name="jsonBody">body in json</param>
+        /// <param name="payload">object payload</param>
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
@@ -1566,7 +1566,7 @@ namespace CustardApi.Objects
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller">name of the controller</param>
         /// <param name="action">name of the action</param>
-        /// <param name="payload">body in json</param>
+        /// <param name="payload">object payload</param>
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>
@@ -1585,7 +1585,7 @@ namespace CustardApi.Objects
         /// <typeparam name="T">type of return</typeparam>
         /// <param name="controller">name of the controller</param>
         /// <param name="action">name of the action</param>
-        /// <param name="payload">body in json</param>
+        /// <param name="payload">object payload</param>
         /// <param name="singleUseHeaders">headers that will only be used in this request</param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>Result of the request</returns>

--- a/CustardApi/Objects/Service.cs
+++ b/CustardApi/Objects/Service.cs
@@ -1099,6 +1099,531 @@ namespace CustardApi.Objects
         }
 
         #endregion
+        #region with object payload
+        #region Path parameters requests
+        /// <summary>
+        /// Execute a post method without header and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// 
+        /// <returns>Result of the request</returns>
+        public Task<T> Post<T>(string controller,
+                               string[] parameters,
+                               object payload,
+                               string action = null,
+                               Action<HttpResponseMessage> unSuccessCallback = null,
+                               IDictionary<string, string> singleUseHeaders = null,
+                               CancellationToken cancellationToken = default)
+        {
+
+            return Process<T>(controller, "application/json", JsonConvert.SerializeObject(payload), action, parameters, HttpMethod.Post, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        /// <summary>
+        /// Execute a get method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Get<T>(string controller,
+                              string[] parameters,
+                              object payload,
+                              string action = null,
+                              Action<HttpResponseMessage> unSuccessCallback = null,
+                              IDictionary<string, string> singleUseHeaders = null,
+                              CancellationToken cancellationToken = default)
+        {
+
+            return Process<T>(controller, "application/json", JsonConvert.SerializeObject(payload), action, parameters, HttpMethod.Get, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a put method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Put<T>(string controller,
+                              string[] parameters,
+                              object payload,
+                              string action = null,
+                              Action<HttpResponseMessage> unSuccessCallback = null,
+                              IDictionary<string, string> singleUseHeaders = null,
+                              CancellationToken cancellationToken = default)
+        {
+
+
+            return Process<T>(controller, "application/json", JsonConvert.SerializeObject(payload), action, parameters, HttpMethod.Put, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a delete method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Delete<T>(string controller,
+                                 string[] parameters,
+                                 object payload,
+                                 string action = null,
+                                 Action<HttpResponseMessage> unSuccessCallback = null,
+                                 IDictionary<string, string> singleUseHeaders = null,
+                                 CancellationToken cancellationToken = default)
+        {
+
+            // Get the reponse
+            return Process<T>(controller, "application/json", JsonConvert.SerializeObject(payload), action, parameters, HttpMethod.Delete, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        /// <summary>
+        /// Execute a get method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Get(string controller,
+                                string[] parameters,
+                                object payload,
+                                string action = null,
+                                Action<HttpResponseMessage> unSuccessCallback = null,
+                                IDictionary<string, string> singleUseHeaders = null,
+                                CancellationToken cancellationToken = default)
+        {
+
+            return Process<string>(controller, "application/json", JsonConvert.SerializeObject(payload), action, parameters, HttpMethod.Get, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a put method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Put(string controller,
+                                string[] parameters,
+                                object payload,
+                                string action = null,
+                                Action<HttpResponseMessage> unSuccessCallback = null,
+                                IDictionary<string, string> singleUseHeaders = null,
+                                CancellationToken cancellationToken = default)
+        {
+            return Process<string>(controller, "application/json", JsonConvert.SerializeObject(payload), action, parameters, HttpMethod.Put, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a post method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Post(string controller,
+                                 string[] parameters,
+                                 object payload,
+                                string action = null,
+                                 Action<HttpResponseMessage> unSuccessCallback = null,
+                                 IDictionary<string, string> singleUseHeaders = null,
+                                 CancellationToken cancellationToken = default)
+        {
+
+            // Get the reponse
+            return Process<string>(controller, "application/json", JsonConvert.SerializeObject(payload), action, parameters, HttpMethod.Post, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a delete method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Delete(string controller,
+                                   string[] parameters,
+                                   object payload,
+                                   string action = null,
+                                   Action<HttpResponseMessage> unSuccessCallback = null,
+                                   IDictionary<string, string> singleUseHeaders = null,
+                                   CancellationToken cancellationToken = default)
+        {
+
+            // Get the reponse
+            return Process<string>(controller, "application/json", JsonConvert.SerializeObject(payload), action, parameters, HttpMethod.Delete, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        #endregion
+
+        #region Query parameters requests
+        /// <summary>
+        /// Execute a post method without header and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// 
+        /// <returns>Result of the request</returns>
+        public Task<T> Post<T>(string controller,
+                               IDictionary<string, string> parameters,
+                               object payload,
+                               string action = null,
+                               Action<HttpResponseMessage> unSuccessCallback = null,
+                               IDictionary<string, string> singleUseHeaders = null,
+                               CancellationToken cancellationToken = default)
+        {
+
+            return Process<T>(controller, "application/json", JsonConvert.SerializeObject(payload), action, parameters, HttpMethod.Post, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        /// <summary>
+        /// Execute a get method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Get<T>(string controller,
+                              IDictionary<string, string> parameters,
+                              object payload,
+                              string action = null,
+                              Action<HttpResponseMessage> unSuccessCallback = null,
+                              IDictionary<string, string> singleUseHeaders = null,
+                              CancellationToken cancellationToken = default)
+        {
+
+            return Process<T>(controller, "application/json", JsonConvert.SerializeObject(payload), JsonConvert.SerializeObject(payload), parameters, HttpMethod.Get, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a put method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Put<T>(string controller,
+                              IDictionary<string, string> parameters,
+                              object payload,
+                              string action = null,
+                              Action<HttpResponseMessage> unSuccessCallback = null,
+                              IDictionary<string, string> singleUseHeaders = null,
+                              CancellationToken cancellationToken = default)
+        {
+
+
+            return Process<T>(controller, "application/json", JsonConvert.SerializeObject(payload), action, parameters, HttpMethod.Put, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a delete method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Delete<T>(string controller,
+                                 IDictionary<string, string> parameters,
+                                 object payload,
+                                 string action = null,
+                                 Action<HttpResponseMessage> unSuccessCallback = null,
+                                 IDictionary<string, string> singleUseHeaders = null,
+                                 CancellationToken cancellationToken = default)
+        {
+
+            // Get the reponse
+            return Process<T>(controller, "application/json", JsonConvert.SerializeObject(payload), action, parameters, HttpMethod.Delete, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+
+        /// <summary>
+        /// Execute a get method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Get(string controller,
+                                IDictionary<string, string> parameters,
+                                 object payload,
+                                string action = null,
+                                Action<HttpResponseMessage> unSuccessCallback = null,
+                                IDictionary<string, string> singleUseHeaders = null,
+                                CancellationToken cancellationToken = default)
+        {
+
+            return Process<string>(controller, "application/json", JsonConvert.SerializeObject(payload), action, parameters, HttpMethod.Get, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a put method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Put(string controller,
+                                IDictionary<string, string> parameters,
+                                 object payload,
+                                string action = null,
+                                Action<HttpResponseMessage> unSuccessCallback = null,
+                                IDictionary<string, string> singleUseHeaders = null,
+                                CancellationToken cancellationToken = default)
+        {
+            return Process<string>(controller, "application/json", JsonConvert.SerializeObject(payload), action, parameters, HttpMethod.Put, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a post method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Post(string controller,
+                                 IDictionary<string, string> parameters,
+                                 object payload,
+                                 string action = null,
+                                 Action<HttpResponseMessage> unSuccessCallback = null,
+                                 IDictionary<string, string> singleUseHeaders = null,
+                                 CancellationToken cancellationToken = default)
+        {
+
+            // Get the reponse
+            return Process<string>(controller, "application/json", JsonConvert.SerializeObject(payload), action, parameters, HttpMethod.Post, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a delete method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Delete(string controller,
+                                   IDictionary<string, string> parameters,
+                                   object payload,
+                                   string action = null,
+                                   Action<HttpResponseMessage> unSuccessCallback = null,
+                                   IDictionary<string, string> singleUseHeaders = null,
+                                   CancellationToken cancellationToken = default)
+        {
+
+            // Get the reponse
+            return Process<string>(controller, "application/json", JsonConvert.SerializeObject(payload), action, parameters, HttpMethod.Delete, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        #endregion
+
+        #region without parameters
+        /// <summary>
+        /// Execute a post method without header and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// 
+        /// <returns>Result of the request</returns>
+        public Task<T> Post<T>(string controller,
+                               object payload,
+                               string action = null,
+                               Action<HttpResponseMessage> unSuccessCallback = null,
+                               IDictionary<string, string> singleUseHeaders = null,
+                               CancellationToken cancellationToken = default)
+        {
+
+            return Process<T>(controller, "application/json", JsonConvert.SerializeObject(payload), action, HttpMethod.Post, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        /// <summary>
+        /// Execute a get method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Get<T>(string controller,
+                              object payload,
+                              string action = null,
+                              Action<HttpResponseMessage> unSuccessCallback = null,
+                              IDictionary<string, string> singleUseHeaders = null,
+                              CancellationToken cancellationToken = default)
+        {
+
+            return Process<T>(controller, "application/json", JsonConvert.SerializeObject(payload), action, HttpMethod.Get, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a put method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Put<T>(string controller,
+                              object payload,
+                              string action = null,
+                              Action<HttpResponseMessage> unSuccessCallback = null,
+                              IDictionary<string, string> singleUseHeaders = null,
+                              CancellationToken cancellationToken = default)
+        {
+
+
+            return Process<T>(controller, "application/json", JsonConvert.SerializeObject(payload), action, HttpMethod.Put, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a delete method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<T> Delete<T>(string controller,
+                                 object payload,
+                                 string action = null,
+                                 Action<HttpResponseMessage> unSuccessCallback = null,
+                                 IDictionary<string, string> singleUseHeaders = null,
+                                 CancellationToken cancellationToken = default)
+        {
+
+            // Get the reponse
+            return Process<T>(controller, "application/json", JsonConvert.SerializeObject(payload), action, HttpMethod.Delete, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        /// <summary>
+        /// Execute a get method and return a string
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="jsonBody">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Get(string controller,
+                                object payload,
+                                string action = null,
+                                Action<HttpResponseMessage> unSuccessCallback = null,
+                                IDictionary<string, string> singleUseHeaders = null,
+                               CancellationToken cancellationToken = default)
+        {
+
+            return Process<string>(controller, "application/json", JsonConvert.SerializeObject(payload), action, HttpMethod.Get, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a put method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="payload">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Put(string controller,
+                                object payload,
+                                string action = null,
+                                Action<HttpResponseMessage> unSuccessCallback = null,
+                                IDictionary<string, string> singleUseHeaders = null,
+                               CancellationToken cancellationToken = default)
+        {
+            return Process<string>(controller, "application/json", JsonConvert.SerializeObject(payload), action, HttpMethod.Put, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a post method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="payload">body in json</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Post(string controller,
+                                 object payload,
+                                 string action = null,
+                                 Action<HttpResponseMessage> unSuccessCallback = null,
+                                 IDictionary<string, string> singleUseHeaders = null,
+                                 CancellationToken cancellationToken = default)
+        {
+
+            // Get the reponse
+            return Process<string>(controller, "application/json", JsonConvert.SerializeObject(payload), action, HttpMethod.Post, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+        /// <summary>
+        /// Execute a delete method and return a model
+        /// </summary>
+        /// <typeparam name="T">type of return</typeparam>
+        /// <param name="controller">name of the controller</param>
+        /// <param name="action">name of the action</param>
+        /// <param name="payload">object payload</param>
+        /// <param name="singleUseHeaders">headers that will only be used in this request</param>
+        /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
+        /// <returns>Result of the request</returns>
+        public Task<string> Delete(string controller,
+                                   object payload,
+                                   string action = null,
+                                   Action<HttpResponseMessage> unSuccessCallback = null,
+                                   IDictionary<string, string> singleUseHeaders = null,
+                                   CancellationToken cancellationToken = default)
+        {
+
+            // Get the reponse
+            return Process<string>(controller, "application/json", JsonConvert.SerializeObject(payload), action, HttpMethod.Delete, cancellationToken, unSuccessCallback, singleUseHeaders: singleUseHeaders);
+        }
+
+        #endregion
+        #endregion
 
         #region Without payload
         #region Path parameters requests
@@ -1709,7 +2234,14 @@ namespace CustardApi.Objects
         /// <param name="action"></param>
         /// <param name="httpMethod"></param>
         /// <returns>response of the method in the form of a model</returns>
-        private async Task<T> Process<T>(string controller, string contentType, HttpContent httpContent, string action, string[] parameters, HttpMethod httpMethod, CancellationToken cancToken, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        private async Task<T> Process<T>(string controller, 
+                                         string contentType, 
+                                         HttpContent httpContent, 
+                                         string action, 
+                                         string[] parameters, 
+                                         HttpMethod httpMethod, 
+                                         CancellationToken cancToken, 
+                                         Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
         {
             try
             {
@@ -1732,7 +2264,15 @@ namespace CustardApi.Objects
         /// <param name="httpMethod"></param>
         /// <param name="unSuccessCallback">Action excecuted in when the call returns an unsuccessful status</param>
         /// <returns>response of the method in the form of a model</returns>
-        private async Task<T> Process<T>(string controller, string contentType, string payload, string action, IDictionary<string, string> parameters, HttpMethod httpMethod, CancellationToken cancToken, Action<HttpResponseMessage> unSuccessCallback = null, IDictionary<string, string> singleUseHeaders = null)
+        private async Task<T> Process<T>(string controller, 
+                                         string contentType, 
+                                         string payload, 
+                                         string action, 
+                                         IDictionary<string, string> parameters, 
+                                         HttpMethod httpMethod, 
+                                         CancellationToken cancToken, 
+                                         Action<HttpResponseMessage> unSuccessCallback = null, 
+                                         IDictionary<string, string> singleUseHeaders = null)
         {
             try
             {

--- a/NUnitTestCustardApi/Objects/ServiceTest.cs
+++ b/NUnitTestCustardApi/Objects/ServiceTest.cs
@@ -398,7 +398,7 @@ namespace NUnitTestCustardApi
             Assert.IsNotNull(resultStr);
         }
         [Test]
-        public async Task PostMethod()
+        public async Task PostMethodJsonPayload()
         {
             // Arrange
             var userToCreate = new ReqresUser
@@ -413,6 +413,27 @@ namespace NUnitTestCustardApi
             var result = await _serviceReqres.Post<ReqresUser>(controller: controller, 
                                                                action: action, 
                                                                jsonBody: JsonConvert.SerializeObject(userToCreate) );
+            
+            // Assert
+            Console.WriteLine(JsonConvert.SerializeObject(result));
+            Assert.IsNotNull(result);
+        }
+        [Test]
+        public async Task PostMethod()
+        {
+            // Arrange
+            var userToCreate = new ReqresUser
+            {
+                Name = "morpheus",
+                Job = "leader"
+            };
+            string action = "users";
+            string controller = "api";
+
+            // Act
+            var result = await _serviceReqres.Post<ReqresUser>(controller: controller, 
+                                                               action: action, 
+                                                               payload: userToCreate );
             
             // Assert
             Console.WriteLine(JsonConvert.SerializeObject(result));

--- a/NUnitTestCustardApi/Objects/ServiceTest.cs
+++ b/NUnitTestCustardApi/Objects/ServiceTest.cs
@@ -398,6 +398,27 @@ namespace NUnitTestCustardApi
             Assert.IsNotNull(resultStr);
         }
         [Test]
+        public async Task PostMethod()
+        {
+            // Arrange
+            var userToCreate = new ReqresUser
+            {
+                Name = "morpheus",
+                Job = "leader"
+            };
+            string action = "users";
+            string controller = "api";
+
+            // Act
+            var result = await _serviceReqres.Post<ReqresUser>(controller: controller,
+                                                               action: action,
+                                                               payload: userToCreate);
+
+            // Assert
+            Console.WriteLine(JsonConvert.SerializeObject(result));
+            Assert.IsNotNull(result);
+        }
+        [Test]
         public async Task PostMethodJsonPayload()
         {
             // Arrange
@@ -413,27 +434,6 @@ namespace NUnitTestCustardApi
             var result = await _serviceReqres.Post<ReqresUser>(controller: controller, 
                                                                action: action, 
                                                                jsonBody: JsonConvert.SerializeObject(userToCreate) );
-            
-            // Assert
-            Console.WriteLine(JsonConvert.SerializeObject(result));
-            Assert.IsNotNull(result);
-        }
-        [Test]
-        public async Task PostMethod()
-        {
-            // Arrange
-            var userToCreate = new ReqresUser
-            {
-                Name = "morpheus",
-                Job = "leader"
-            };
-            string action = "users";
-            string controller = "api";
-
-            // Act
-            var result = await _serviceReqres.Post<ReqresUser>(controller: controller, 
-                                                               action: action, 
-                                                               payload: userToCreate );
             
             // Assert
             Console.WriteLine(JsonConvert.SerializeObject(result));


### PR DESCRIPTION
Per #22, the goal was to add the option for each request to add a payload as an object directly in the method.
This was to avoid unnecessary code.

### Example 
``` Csharp
 // Create your payload object
 var userToCreate = new ReqresUser
 {
     Name = "Jackson",
     Job = "Writer content",
 };
 string action = "users";
 string controller = "api";

 // Send the request
 var result = await _serviceReqres.Post<ReqresUser>(controller, action: action, payload: userToCreate);
```

(you'll still be able to send a JSON directly using `jsonBody` instead of `payload`)
