### PR TITLE
#37 Optimise Service calls by using Stream instead of string conversion

### DIFF
--- a/NUnitTestCustardApi/Objects/ServiceTest.cs
+++ b/NUnitTestCustardApi/Objects/ServiceTest.cs
@@ -478,7 +478,7 @@ namespace NUnitTestCustardApi
 
             // Assert
             Console.WriteLine(JsonConvert.SerializeObject(result));
-            Assert.IsNotNull(result);
+            Assert.Pass();
         }
         [Test]
         [Timeout(5000)] // 5 seconds


### PR DESCRIPTION
Per #37, these changes aim at optimising the method used to call the web services by returning the data using a stream